### PR TITLE
Remove specific pnpm version in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
+        
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Removed the specific `pnpm` version from the CI workflow.

- Simplified the `pnpm` installation step in `ci.yml`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Simplify `pnpm` installation in CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<li>Removed the <code>version</code> field for <code>pnpm</code> installation.<br> <li> Simplified the <code>pnpm</code> setup step in the CI workflow.


</details>


  </td>
  <td><a href="https://github.com/mudiageo/svelte-guardian/pull/5/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>